### PR TITLE
[#9] 페이징

### DIFF
--- a/src/main/java/persi/makeboard/board/dto/BoardDto.java
+++ b/src/main/java/persi/makeboard/board/dto/BoardDto.java
@@ -21,6 +21,14 @@ public class BoardDto {
     private LocalDateTime boardCreatedTime;
     private LocalDateTime boardUpdatedTime;
 
+    public BoardDto(Long id, String boardWriter, String boardTitle, int boardHits, LocalDateTime boardCreatedTime) {
+        this.id = id;
+        this.boardWriter = boardWriter;
+        this.boardTitle = boardTitle;
+        this.boardHits = boardHits;
+        this.boardCreatedTime = boardCreatedTime;
+    }
+
     public static BoardDto toBoardDto(Board board){
         BoardDto boardDto = new BoardDto();
         boardDto.setId(board.getId());

--- a/src/main/java/persi/makeboard/board/service/BoardService.java
+++ b/src/main/java/persi/makeboard/board/service/BoardService.java
@@ -2,6 +2,10 @@ package persi.makeboard.board.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import persi.makeboard.board.domain.Board;
 import persi.makeboard.board.dto.BoardDto;
@@ -57,7 +61,29 @@ public class BoardService {
         return findById(boardDto.getId());
     }
 
+    // 게시물 삭제
     public void delete(Long id) {
         boardRepository.deleteById(id);
+    }
+
+    // 게시물 페이징
+    public Page<BoardDto> paging(Pageable pageable) {
+        int page = pageable.getPageNumber() -1 ;
+        int pageLimit = 3; // 한 페이지에 보여줄 글 갯수
+        // 한 페이지당 3개씩 글을 보여주고 정렬 기준은 id 기준으로 내림차순 정렬
+        // page 위치에 있는 값은 0부터 시작. 실제로 보고 싶은 값은 1 -> -1 해줌
+        Page<Board> boards = boardRepository.findAll(PageRequest.of(page, pageLimit, Sort.by(Sort.Direction.DESC, "id")));
+        System.out.println("boardEntities.getContent() = " + boards.getContent()); // 요청 페이지에 해당하는 글
+        System.out.println("boardEntities.getTotalElements() = " + boards.getTotalElements()); // 전체 글갯수
+        System.out.println("boardEntities.getNumber() = " + boards.getNumber()); // DB로 요청한 페이지 번호
+        System.out.println("boardEntities.getTotalPages() = " + boards.getTotalPages()); // 전체 페이지 갯수
+        System.out.println("boardEntities.getSize() = " + boards.getSize()); // 한 페이지에 보여지는 글 갯수
+        System.out.println("boardEntities.hasPrevious() = " + boards.hasPrevious()); // 이전 페이지 존재 여부
+        System.out.println("boardEntities.isFirst() = " + boards.isFirst()); // 첫 페이지 여부
+        System.out.println("boardEntities.isLast() = " + boards.isLast()); // 마지막 페이지 여부
+
+        // 목록: id, writer, title, hits, createdTime
+        Page<BoardDto> boardDtos = boards.map(board -> new BoardDto(board.getId(), board.getBoardWriter(), board.getBoardTitle(), board.getBoardHits(), board.getCreatedTime()));
+        return boardDtos; // Page 객체로 리턴
     }
 }

--- a/src/main/resources/templates/detail.html
+++ b/src/main/resources/templates/detail.html
@@ -38,7 +38,8 @@
 <script th:inline="javascript">
     const listReq = () => {
         console.log("목록 요청");
-        location.href = "/board/";
+        const page = [[${page}]] ? [[${page}]] : 1;
+        location.href = "/board/paging?page=" + page;
     }
     const updateReq = () => {
         console.log("수정 요청");

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -9,7 +9,8 @@
 <!--
     <a href="/board/save">글작성(링크)</a>
 -->
-        <button onclick="listReq()">글목록</button>
+    <button onclick="listReq()">글목록</button>
+    <button onclick="pagingReq()">페이징 목록</button>
 </body>
 <script>
     const saveReq = () => {
@@ -17,6 +18,9 @@
     }
     const listReq = () => {
         location.href = "/board/"
+    }
+    const pagingReq = () => {
+        location.href = "/board/paging"
     }
 
 </script>

--- a/src/main/resources/templates/paging.html
+++ b/src/main/resources/templates/paging.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<button onclick="saveReq()">글작성</button>
+
+<table>
+    <tr>
+        <th>id</th>
+        <th>title</th>
+        <th>writer</th>
+        <th>date</th>
+        <th>hits</th>
+    </tr>
+    <tr th:each="board: ${boardList}">
+        <td th:text="${board.id}"></td>
+
+        <!-- 게시판 상세 조회시 페이지 저장 -->
+        <td><a th:href="@{|/board/${board.id}?page=${boardList.number + 1}|}" th:text="${board.boardTitle}"></a></td>
+
+        <td th:text="${board.boardWriter}"></td>
+        <td th:text="*{#temporals.format(board.boardCreatedTime, 'yyyy-MM-dd HH:mm:ss')}"></td>
+        <td th:text="${board.boardHits}"></td>
+    </tr>
+</table>
+<!-- 첫번째 페이지로 이동 -->
+<!-- /board/paging?page=1 -->
+<a th:href="@{/board/paging(page=1)}">First</a>
+<!-- 이전 링크 활성화 비활성화 -->
+<!-- boardList.getNumber() 사용자:2페이지 getNumber()=1 -->
+<!--<a th:href="${boardList.first} ? '#' : @{/board/paging(page=${boardList.number})}">prev</a>-->
+<a th:href="${boardList.first} ? '#' : '/board/paging?page=' + ${boardList.number}">prev</a>
+
+<!-- 페이지 번호 링크(현재 페이지는 숫자만)
+        for(int page=startPage; page<=endPage; page++)-->
+<span th:each="page: ${#numbers.sequence(startPage, endPage)}">
+<!-- 현재페이지는 링크 없이 숫자만 -->
+    <span th:if="${page == boardList.number + 1}" th:text="${page}"></span>
+    <!-- 현재페이지 번호가 아닌 다른 페이지번호에는 링크를 보여줌 -->
+    <span th:unless="${page == boardList.number + 1}">
+        <a th:href="@{/board/paging(page=${page})}" th:text="${page}"></a>
+    </span>
+</span>
+
+<!-- 다음 링크 활성화 비활성화
+    사용자: 2페이지, getNumber: 1, 3페이지-->
+<!--<a th:href="${boardList.last} ? '#' : @{/board/paging(page=${boardList.number + 2})}">next</a>-->
+<a th:href="${boardList.last} ? '#' : '/board/paging?page=' + ${boardList.number + 2}">next</a>
+
+<!-- 마지막 페이지로 이동 -->
+<a th:href="@{/board/paging(page=${boardList.totalPages})}">Last</a>
+
+</body>
+<script>
+    const saveReq = () => {
+        location.href = "/board/save";
+    }
+
+</script>
+</html>


### PR DESCRIPTION
## PR 타입
- 기능 추가

## 반영 브랜치
- feature/9 -> develop

## 변경 사항
- 게시글 페이징 기능 구현

## 테스트 결과
index.html
![image](https://github.com/persi0815/board-crud/assets/121751509/1a35bcd9-83ad-4d7e-aa1c-9d5ca987618d)

1페이지가 디폴트
![image](https://github.com/persi0815/board-crud/assets/121751509/f99fd7a0-fdaa-45ce-b918-d1c09e4a85b3)

prev, next로 할 페이지 없으면 '#'추가
![image](https://github.com/persi0815/board-crud/assets/121751509/67f5f18b-6f18-4c2a-9622-248980b5d1fc)

상세조회시 board id와 page 번호 쿼리로 넘김
![image](https://github.com/persi0815/board-crud/assets/121751509/09d8e2c1-9c86-4f58-9809-8c7f3e963363)

목록으로 되돌아왔을때 페이지 그대로 유지
![image](https://github.com/persi0815/board-crud/assets/121751509/83608190-f224-439a-8181-fecab73895b7)

페이지 수정 후 되돌아가면
![image](https://github.com/persi0815/board-crud/assets/121751509/8bcb593c-e861-4e43-8760-150e4b0e3ae9)
페이지 값이 저장이 안됨
![image](https://github.com/persi0815/board-crud/assets/121751509/dbd64693-5cd7-4cad-b7fd-6888bf8c2754)
해당 상태에서 목록으로 되돌아가면 1페이지로 가게끔 설정해놓음
![image](https://github.com/persi0815/board-crud/assets/121751509/f2b8ca33-dc67-4184-bd1b-2aeee104a367)

## 보완할 사항
- 수정 후 추후 게시글이 존재했던 페이지로 돌아가게끔 수정할 예정
- 게시글 삭제 이후에 바로 목록(/board/)으로 가게끔 되어있는데, 이 부분도 페이징 처리 할 예정